### PR TITLE
Add: Vertical Half CutMix Augmentation

### DIFF
--- a/code/mmdetection/mmdet/datasets/pipelines/__init__.py
+++ b/code/mmdetection/mmdet/datasets/pipelines/__init__.py
@@ -15,6 +15,8 @@ from .transforms import (Albu, CopyPaste, CutOut, Expand, MinIoURandomCrop,
                          RandomAffine, RandomCenterCropPad, RandomCrop,
                          RandomFlip, RandomShift, Resize, SegRescale,
                          YOLOXHSVRandomAug)
+from .transforms_custom import (VerticalHalfCutMix)
+
 
 __all__ = [
     'Compose', 'to_tensor', 'ToTensor', 'ImageToTensor', 'ToDataContainer',
@@ -27,5 +29,5 @@ __all__ = [
     'AutoAugment', 'CutOut', 'Shear', 'Rotate', 'ColorTransform',
     'EqualizeTransform', 'BrightnessTransform', 'ContrastTransform',
     'Translate', 'RandomShift', 'Mosaic', 'MixUp', 'RandomAffine',
-    'YOLOXHSVRandomAug', 'CopyPaste'
+    'YOLOXHSVRandomAug', 'CopyPaste', 'VerticalHalfCutMix'
 ]

--- a/code/mmdetection/mmdet/datasets/pipelines/transforms_custom.py
+++ b/code/mmdetection/mmdet/datasets/pipelines/transforms_custom.py
@@ -1,0 +1,121 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+import inspect
+import math
+import warnings
+
+import cv2
+import mmcv
+import numpy as np
+from numpy import random
+
+from mmdet.core import BitmapMasks, PolygonMasks, find_inside_bboxes
+from mmdet.core.evaluation.bbox_overlaps import bbox_overlaps
+from mmdet.utils import log_img_scale
+from ..builder import PIPELINES
+
+try:
+    from imagecorruptions import corrupt
+except ImportError:
+    corrupt = None
+
+
+@PIPELINES.register_module()
+class VerticalHalfCutMix:
+
+    def __init__(self,
+                 max_iters=15,
+                 prob=0.5):
+        # log_img_scale(img_scale, skip_square=True)
+        assert 0 <= prob <= 1
+        self.max_iters = max_iters
+        self.prob = prob
+
+
+    def __call__(self, results):
+        """Call function to make a mixup of image.
+
+        Args:
+            results (dict): Result dict.
+
+        Returns:
+            dict: Result dict with mixup transformed.
+        """
+        if random.random() < self.prob:
+            results = self._vertical_cutmix_transform(results)
+        return results
+
+    def get_indexes(self, dataset):
+        """Call function to collect indexes.
+
+        Args:
+            dataset (:obj:`MultiImageMixDataset`): The dataset.
+
+        Returns:
+            list: indexes.
+        """
+
+        for i in range(self.max_iters):
+            index = random.randint(0, len(dataset))
+            gt_bboxes_i = dataset.get_ann_info(index)['bboxes']
+            if len(gt_bboxes_i) != 0:
+                break
+
+        return index
+
+    def _vertical_cutmix_transform(self, results):
+        assert 'mix_results' in results
+        assert len(
+            results['mix_results']) == 1, 'MixUp only support 2 images now !'
+
+        if results['mix_results'][0]['gt_bboxes'].shape[0] == 0:
+            # empty bbox
+            return results
+
+        img_2_results = results['mix_results'][0]
+        img_2 = img_2_results['img']
+
+        img_1 = results['img']
+
+        img_1_bboxes = results['gt_bboxes']
+        img_1_labels = results['gt_labels']
+        img_2_bboxes = img_2_results['gt_bboxes']
+        img_2_labels = img_2_results['gt_labels']
+
+        origin_h, origin_w = img_1.shape[:2]
+        target_h, target_w = img_2.shape[:2]
+        half_target_w = int(target_w / 2)
+
+        cutmix_img = np.zeros((origin_h, origin_w, 3)).astype(np.uint8)
+
+        cutmix_val = 0
+        if np.random.randint(0, 2) == 1:
+            cutmix_val = 1
+        # cutmix_val = 1
+        # print(cutmix_val)
+
+        if cutmix_val == 1:
+            cutmix_img[:, 0:half_target_w] = img_1[:, 0:half_target_w]
+            cutmix_img[:, half_target_w:-1] = img_2[:, half_target_w:-1]
+
+            idxes_1, idxes_2 = (img_1_bboxes[:, 0] < half_target_w), (img_2_bboxes[:, 0] >= half_target_w)
+            l_1, l_2 = img_1_labels[idxes_1], img_2_labels[idxes_2]
+            b_1, b_2 = img_1_bboxes[idxes_1], img_2_bboxes[idxes_2]
+
+        else:
+            cutmix_img[:, 0:half_target_w] = img_2[:, 0:half_target_w]
+            cutmix_img[:, half_target_w:-1] = img_1[:, half_target_w:-1]
+
+            idxes_1, idxes_2 = (img_1_bboxes[:, 0] >= half_target_w), (img_2_bboxes[:, 0] < half_target_w)
+            l_1, l_2 = img_1_labels[idxes_1], img_2_labels[idxes_2]
+            b_1, b_2 = img_1_bboxes[idxes_1], img_2_bboxes[idxes_2]
+
+        cutmix_labels = np.concatenate((l_1, l_2), axis=0)
+        cutmix_bboxes = np.concatenate((b_1, b_2), axis=0)
+
+        results['img'] = cutmix_img.astype(np.uint8)
+        results['gt_bboxes'] = cutmix_bboxes
+        results['gt_labels'] = cutmix_labels
+
+        return results
+        


### PR DESCRIPTION
## Overview
모델 학습을 위한 Vertical Half CutMix Augmentation 를 추가합니다.

***VerticalHalfCutMix***
두 이미지를 세로로 절반씩 자른 후 합성시킵니다

Args:
- prob (float): Aug 가 실행할 확률을 결정합니다, default=0.5


## Change Log
mmdetection/mmdet/datasets/pipelines 폴더 내
- __init__.py 수정
- transforms_custom.py 추가

## How to use

VerticalHalfCutMix 를 사용하기 위해서는 dataset.py 컨픽 파일을 다음과 같은 형태로 수정해야 합니다.

```python
train_pipeline = [
    dict(type="Resize", img_scale=(1448, 1024), keep_ratio=True),
    dict(type='VerticalHalfCutMix', prob=0.5),
    dict(type='Normalize', **img_norm_cfg),
    dict(type='Pad', size_divisor=32),
    dict(type='DefaultFormatBundle'),
    dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels'])
]

train_dataset = dict(
#    _delete_ = True, # remove unnecessary Settings
    type='MultiImageMixDataset',
    dataset=dict(
        type=dataset_type,
        ann_file=data_root + 'annotations/{train annotation.json 파일}',
        img_prefix=data_root + '{train dataset 경로/}',
        classes=classes,
        pipeline=[
            dict(type='LoadImageFromFile'),
            dict(type='LoadAnnotations', with_bbox=True)
        ],
        filter_empty_gt=False,
    ),
    pipeline=train_pipeline
    )

data = dict(
    ...
    train=train_dataset,
    ...
    )
```

## To Reviewer
버그발견, 수정 및 개선사항이 있으면 알려주세요
