### PR TITLE
database 분리 / log 기록 / 오류 수정

### DIFF
--- a/code/fastapi/app/back/.gitignore
+++ b/code/fastapi/app/back/.gitignore
@@ -1,0 +1,1 @@
+db_secrets.json

--- a/code/fastapi/app/back/database.py
+++ b/code/fastapi/app/back/database.py
@@ -1,0 +1,63 @@
+import json
+import pandas as pd
+import psycopg2
+from datetime import datetime
+
+
+# db 연결
+db_secrets_path = "/opt/ml/input/code/fastapi/app/back/db_secrets.json"
+with open(db_secrets_path, "r") as f:
+    db_secrets = json.load(f)
+db = psycopg2.connect(
+    host=db_secrets["DB"]["host"],
+    dbname=db_secrets["DB"]["dbname"],
+    user=db_secrets["DB"]["user"],
+    password=db_secrets["DB"]["password"],
+    port=db_secrets["DB"]["port"],
+)
+
+
+def get_info_from_db(exam_info):
+    answer = pd.read_sql(
+        f'select "QUESTION_PK", "ANSWER" from "ANSWER_TB" Where "TYPE_PK" like \'%{exam_info}%\';',
+        db,
+    )
+    question = pd.read_sql(
+        f'select "QUESTION_PK", x, y, w, h, page from "QUESTION_BBOX_TB" Where "TYPE_PK" like \'%{exam_info}%\';',
+        db,
+    )
+    img_shape = pd.read_sql(
+        f'select "WIDTH", "HEIGHT" from "PAGE_SHAPE" where "TYPE_PK" like \'%{exam_info}%\';',
+        db,
+    )
+
+    answer = {q: a for q, a in zip(answer["QUESTION_PK"], answer["ANSWER"])}
+    q_bbox = [[dict()] for _ in range(max(question["page"]))]
+    for q, x, y, w, h, page in zip(
+        question["QUESTION_PK"],
+        question["x"],
+        question["y"],
+        question["w"],
+        question["h"],
+        question["page"],
+    ):
+        q_bbox[page - 1][0].update({q: [x, y, w, h]})
+    img_shape = [img_shape["WIDTH"][0], img_shape["HEIGHT"][0]]
+
+    # db.close() # 매번 close?
+    return answer, q_bbox, img_shape
+
+
+def insert_log(log_pred, exam_info, log_name):
+    time = datetime.now()
+    db.cursor().execute(
+        f'insert into "LOG_UUID" ("INFER_DATE", "UUID") \
+                                values (\'{time}\', \'{log_name}\');'
+    )
+    for p in log_pred:
+        x, y, w, h, confidence, question_num, pred = p
+        db.cursor().execute(
+            f'insert into "LOG" ("TYPE_PK", "INFER_DATE", x, y, w, h, confidence, "QUESTION_PK", "PRED") \
+                                values (\'{exam_info}\', \'{time}\', {x}, {y}, {w}, {h}, {confidence}, {pred}, {question_num});'
+        )
+        db.commit()

--- a/code/fastapi/app/back/database.py
+++ b/code/fastapi/app/back/database.py
@@ -1,63 +1,93 @@
 import json
 import pandas as pd
 import psycopg2
-from datetime import datetime
 
 
 # db 연결
 db_secrets_path = "/opt/ml/input/code/fastapi/app/back/db_secrets.json"
 with open(db_secrets_path, "r") as f:
     db_secrets = json.load(f)
-db = psycopg2.connect(
-    host=db_secrets["DB"]["host"],
-    dbname=db_secrets["DB"]["dbname"],
-    user=db_secrets["DB"]["user"],
-    password=db_secrets["DB"]["password"],
-    port=db_secrets["DB"]["port"],
-)
+# db = psycopg2.connect(
+#     host=db_secrets["DB"]["host"],
+#     dbname=db_secrets["DB"]["dbname"],
+#     user=db_secrets["DB"]["user"],
+#     password=db_secrets["DB"]["password"],
+#     port=db_secrets["DB"]["port"],
+# )
 
 
 def get_info_from_db(exam_info):
+    db = psycopg2.connect(
+        host=db_secrets["DB"]["host"],
+        dbname=db_secrets["DB"]["dbname"],
+        user=db_secrets["DB"]["user"],
+        password=db_secrets["DB"]["password"],
+        port=db_secrets["DB"]["port"],
+    )
+
     answer = pd.read_sql(
-        f'select "QUESTION_PK", "ANSWER" from "ANSWER_TB" Where "TYPE_PK" like \'%{exam_info}%\';',
-        db,
-    )
-    question = pd.read_sql(
-        f'select "QUESTION_PK", x, y, w, h, page from "QUESTION_BBOX_TB" Where "TYPE_PK" like \'%{exam_info}%\';',
-        db,
-    )
-    img_shape = pd.read_sql(
-        f'select "WIDTH", "HEIGHT" from "PAGE_SHAPE" where "TYPE_PK" like \'%{exam_info}%\';',
+        f"""
+        select question, answer 
+        from answer_sheet 
+        where type 
+        like \'%{exam_info}%\';
+        """,
         db,
     )
 
-    answer = {q: a for q, a in zip(answer["QUESTION_PK"], answer["ANSWER"])}
+    question = pd.read_sql(
+        f"""
+        select question, x_question, y_question, w_question, h_question, page 
+        from question_bbox 
+        where type 
+        like '%{exam_info}%';
+        """,
+        db,
+    )
+
+    img_shape = pd.read_sql(
+        f"""
+        select width, height 
+        from page_shape 
+        where type 
+        like \'%{exam_info}%\';
+        """,
+        db,
+    )
+
+    answer = {q: a for q, a in zip(answer["question"], answer["answer"])}
     q_bbox = [[dict()] for _ in range(max(question["page"]))]
     for q, x, y, w, h, page in zip(
-        question["QUESTION_PK"],
-        question["x"],
-        question["y"],
-        question["w"],
-        question["h"],
+        question["question"],
+        question["x_question"],
+        question["y_question"],
+        question["w_question"],
+        question["h_question"],
         question["page"],
     ):
         q_bbox[page - 1][0].update({q: [x, y, w, h]})
-    img_shape = [img_shape["WIDTH"][0], img_shape["HEIGHT"][0]]
+    img_shape = [img_shape["width"][0], img_shape["height"][0]]
 
-    # db.close() # 매번 close?
+    db.close()
     return answer, q_bbox, img_shape
 
 
-def insert_log(log_pred, exam_info, log_name):
-    time = datetime.now()
-    db.cursor().execute(
-        f'insert into "LOG_UUID" ("INFER_DATE", "UUID") \
-                                values (\'{time}\', \'{log_name}\');'
+def insert_log(log_pred, exam_info, time):
+    db = psycopg2.connect(
+        host=db_secrets["DB"]["host"],
+        dbname=db_secrets["DB"]["dbname"],
+        user=db_secrets["DB"]["user"],
+        password=db_secrets["DB"]["password"],
+        port=db_secrets["DB"]["port"],
     )
+
     for p in log_pred:
-        x, y, w, h, confidence, question_num, pred = p
+        x_pred, y_pred, w_pred, h_pred, confidence, question_num, pred = p
         db.cursor().execute(
-            f'insert into "LOG" ("TYPE_PK", "INFER_DATE", x, y, w, h, confidence, "QUESTION_PK", "PRED") \
-                                values (\'{exam_info}\', \'{time}\', {x}, {y}, {w}, {h}, {confidence}, {pred}, {question_num});'
+            f"""
+            insert into log (type, question, infer_date, x_pred, y_pred, w_pred, h_pred, confidence, class_pred) 
+            values (\'{exam_info}\', {question_num}, \'{time}\', {x_pred}, {y_pred}, {w_pred}, {h_pred}, {confidence}, {pred});
+            """
         )
         db.commit()
+    db.close()

--- a/code/fastapi/app/back/database.py
+++ b/code/fastapi/app/back/database.py
@@ -82,11 +82,11 @@ def insert_log(log_pred, exam_info, time):
     )
 
     for p in log_pred:
-        x_pred, y_pred, w_pred, h_pred, confidence, question_num, pred = p
+        x_pred, y_pred, w_pred, h_pred, confidence, pred, question = p
         db.cursor().execute(
             f"""
             insert into log (type, question, infer_date, x_pred, y_pred, w_pred, h_pred, confidence, class_pred) 
-            values (\'{exam_info}\', {question_num}, \'{time}\', {x_pred}, {y_pred}, {w_pred}, {h_pred}, {confidence}, {pred});
+            values (\'{exam_info}\', {question}, \'{time}\', {x_pred}, {y_pred}, {w_pred}, {h_pred}, {confidence}, {pred});
             """
         )
         db.commit()

--- a/code/fastapi/app/back/inference.py
+++ b/code/fastapi/app/back/inference.py
@@ -298,14 +298,14 @@ def save_score_img(self, scoring_result):
 
 
 class Inference_v2:
-    def __init__(self, images, detector, q_bbox, answer, img_shape, log_name):
+    def __init__(self, images, detector, q_bbox, answer, img_shape, time):
         self.images = images
         self.detector = detector
         self.q_bbox = q_bbox
         self.answer = answer
         self.inference_detector = inference_detector
         self.origin_img_shape = img_shape
-        self.log_name = log_name
+        self.time = time
 
     def ltrb2xywh(self, bbox):
         return [bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1]]
@@ -354,7 +354,7 @@ class Inference_v2:
         )
         cv2.rectangle(img, (x, y), (x + w, y + h), (255, 0, 0), 3)
         cv2.imwrite(
-            f"/opt/ml/input/code/fastapi/app/log/{self.log_name}/{img_path}_predict.jpg",
+            f"/opt/ml/input/code/fastapi/app/log/{self.time}/{img_path}_predict.jpg",
             img,
         )
 
@@ -405,7 +405,6 @@ class Inference_v2:
             for i in range(len(predict)):
                 predict[i] = self.ltrb2xywh(predict[i][:4]) + predict[i][4:]
             question = self.q_bbox[idx][0]
-
             for q in question:
                 tmp = []
                 for p in predict:

--- a/code/fastapi/app/back/inference.py
+++ b/code/fastapi/app/back/inference.py
@@ -3,274 +3,274 @@ from PIL import Image
 from copy import deepcopy
 from utils import *
 import cv2
-from datetime import datetime
 
 
-# class Inference:
-#     def __init__(self, images, exam_info, coco, detector):
-#         self.images = images
-#         self.coco = coco
-#         self.detector = detector
-#         self.exam_info = self.load_exam_info(exam_info)
-#         self.inference_detector = inference_detector
+class Inference:
+    def __init__(self, images, exam_info, coco, detector):
+        self.images = images
+        self.coco = coco
+        self.detector = detector
+        self.exam_info = self.load_exam_info(exam_info)
+        self.inference_detector = inference_detector
 
-#     def load_exam_info(self, exam_info):
-#         """
-#         img info를 불러오는 함수
+    def load_exam_info(self, exam_info):
+        """
+        img info를 불러오는 함수
 
-#         Args:
-#             exam_info (str): 시험지의 정보 {년도}_{몇월}_{형}
-#                             ex) 2013_9_a or 2022_f
+        Args:
+            exam_info (str): 시험지의 정보 {년도}_{몇월}_{형}
+                            ex) 2013_9_a or 2022_f
 
-#             coco : 사전에 제작된 annotation기반 coco format 데이터
+            coco : 사전에 제작된 annotation기반 coco format 데이터
 
-#         Returns:
-#             List: exam_info에 대응하는 img파일들의 사전 정보
-#             ex) : exam_info = 2012_9_a 일때 12년 9월 a형에 문제 정보가 p1 ~ 마지막 페이지까지 리스트에 담김
-#                 [2012_9_a_p1 정보, 2012_9_a_p2 정보 .....]
-#         """
-#         all_img_info = self.coco.loadImgs(self.coco.getImgIds())
-#         result = [info for info in all_img_info if exam_info in info["file_name"]]
-#         result = sorted(result, key=lambda x: x["file_name"])
-#         return result
+        Returns:
+            List: exam_info에 대응하는 img파일들의 사전 정보
+            ex) : exam_info = 2012_9_a 일때 12년 9월 a형에 문제 정보가 p1 ~ 마지막 페이지까지 리스트에 담김
+                [2012_9_a_p1 정보, 2012_9_a_p2 정보 .....]
+        """
+        all_img_info = self.coco.loadImgs(self.coco.getImgIds())
+        result = [info for info in all_img_info if exam_info in info["file_name"]]
+        result = sorted(result, key=lambda x: x["file_name"])
+        return result
 
-#     def load_anns(self, idx):
-#         img_info = self.exam_info[idx]
-#         ann_ids = self.coco.getAnnIds(imgIds=img_info["id"])
-#         anns = self.coco.loadAnns(ann_ids)
-#         return img_info, anns
+    def load_anns(self, idx):
+        img_info = self.exam_info[idx]
+        ann_ids = self.coco.getAnnIds(imgIds=img_info["id"])
+        anns = self.coco.loadAnns(ann_ids)
+        return img_info, anns
 
-#     def load_anns_q(self, idx):
-#         """
-#         시험의 정보와 이미지를 받아 그것에 대응되는 사전에 annotation된 questions을 반환
-#         """
-#         _, anns = self.load_anns(idx)
-#         questions = [ann for ann in anns if ann["category_id"] > 6]
-#         anns_dict = {q["category_id"]: self.xywh2ltrb(q["bbox"]) for q in questions}
-#         return anns_dict
+    def load_anns_q(self, idx):
+        """
+        시험의 정보와 이미지를 받아 그것에 대응되는 사전에 annotation된 questions을 반환
+        """
+        _, anns = self.load_anns(idx)
+        questions = [ann for ann in anns if ann["category_id"] > 6]
+        anns_dict = {q["category_id"]: self.xywh2ltrb(q["bbox"]) for q in questions}
+        return anns_dict
 
-#     def get_predict(self, img, box_threshold=0.3):
-#         """_summary_
+    def get_predict(self, img, box_threshold=0.3):
+        """_summary_
 
-#         Args:
-#             img: img 파일의 경로
-#             detector: 사전에 제작된 mmdetection 모델
-#             box_threshold (float, optional): detector로 예측된 box들의 최소 임계값
+        Args:
+            img: img 파일의 경로
+            detector: 사전에 제작된 mmdetection 모델
+            box_threshold (float, optional): detector로 예측된 box들의 최소 임계값
 
-#         Returns:
-#             List: [np.array(left,top,right,bottom,label) .... ]
-#             list안의 값은 np.array 형식으로 박스정보와 label 값이 int type으로 정의됨
-#         """
-#         inference = self.inference_detector(self.detector, img)
-#         predict = []
-#         for label, bboxes in enumerate(inference):
-#             predict += [
-#                 np.append(bbox[:4], [bbox[4], label])
-#                 for bbox in bboxes
-#                 if (bbox[4] > box_threshold)
-#             ]
-#         predict = sorted(predict, key=lambda x: x[4], reverse=True)
-#         return predict
+        Returns:
+            List: [np.array(left,top,right,bottom,label) .... ]
+            list안의 값은 np.array 형식으로 박스정보와 label 값이 int type으로 정의됨
+        """
+        inference = self.inference_detector(self.detector, img)
+        predict = []
+        for label, bboxes in enumerate(inference):
+            predict += [
+                np.append(bbox[:4], [bbox[4], label])
+                for bbox in bboxes
+                if (bbox[4] > box_threshold)
+            ]
+        predict = sorted(predict, key=lambda x: x[4], reverse=True)
+        return predict
 
-#     def xywh2ltrb(self, bbox):
-#         """
-#         Args: (x,y)는 좌측 상단
-#             bbox: (x,y,w,h)
+    def xywh2ltrb(self, bbox):
+        """
+        Args: (x,y)는 좌측 상단
+            bbox: (x,y,w,h)
 
-#         Returns:
-#             bbox: (left,top,right,bottom)
-#         """
-#         return bbox[0], bbox[1], bbox[0] + bbox[2], bbox[1] + bbox[3]
+        Returns:
+            bbox: (left,top,right,bottom)
+        """
+        return bbox[0], bbox[1], bbox[0] + bbox[2], bbox[1] + bbox[3]
 
-#     def compute_iou(self, box1, box2):
-#         """iou 계산
+    def compute_iou(self, box1, box2):
+        """iou 계산
 
-#         Args:
-#             box :(List): [left,top,right,bottom]
+        Args:
+            box :(List): [left,top,right,bottom]
 
-#         Returns:
-#             iou(float): box1과 box2의 iou값 반환
-#         """
-#         x1 = np.maximum(box1[0], box2[0])
-#         y1 = np.maximum(box1[1], box2[1])
-#         x2 = np.minimum(box1[2], box2[2])
-#         y2 = np.minimum(box1[3], box2[3])
+        Returns:
+            iou(float): box1과 box2의 iou값 반환
+        """
+        x1 = np.maximum(box1[0], box2[0])
+        y1 = np.maximum(box1[1], box2[1])
+        x2 = np.minimum(box1[2], box2[2])
+        y2 = np.minimum(box1[3], box2[3])
 
-#         box1_area = (box1[2] - box1[0]) * (box1[3] - box1[1])
-#         box2_area = (box2[2] - box2[0]) * (box2[3] - box2[1])
-#         intersection = np.maximum(x2 - x1, 0) * np.maximum(y2 - y1, 0)
-#         union = box1_area + box2_area - intersection
+        box1_area = (box1[2] - box1[0]) * (box1[3] - box1[1])
+        box2_area = (box2[2] - box2[0]) * (box2[3] - box2[1])
+        intersection = np.maximum(x2 - x1, 0) * np.maximum(y2 - y1, 0)
+        union = box1_area + box2_area - intersection
 
-#         iou = intersection / union
-#         assert iou <= 1, "iou값이 1 초과"
-#         return iou
+        iou = intersection / union
+        assert iou <= 1, "iou값이 1 초과"
+        return iou
 
-#     def match_qa(self, anns):
-#         """
-#         사전에 정의된 annotation을 기반으로 같은 문제의 question 박스와 answer 박스를 매칭
-#         Args:
-#             anns : 사전에 정의된 annotation 정보
+    def match_qa(self, anns):
+        """
+        사전에 정의된 annotation을 기반으로 같은 문제의 question 박스와 answer 박스를 매칭
+        Args:
+            anns : 사전에 정의된 annotation 정보
 
-#         Returns:
-#             anns_dict (dict): 문제에 대응하는 정답 박스의 위치 반환
-#             key : category_id
-#             value : answer box의 정보 : left,top,right,bottom
-#         """
+        Returns:
+            anns_dict (dict): 문제에 대응하는 정답 박스의 위치 반환
+            key : category_id
+            value : answer box의 정보 : left,top,right,bottom
+        """
 
-#         questions = [ann for ann in anns if ann["category_id"] > 6]
-#         answers = [ann for ann in anns if ann["category_id"] <= 6]
+        questions = [ann for ann in anns if ann["category_id"] > 6]
+        answers = [ann for ann in anns if ann["category_id"] <= 6]
 
-#         # 추후에 중복되는 연산 제거하는 코드로 수정하기!!
-#         anns_dict = {}
-#         for q in questions:
-#             q_ = self.xywh2ltrb(q["bbox"])
-#             for a in answers:
-#                 a_ = self.xywh2ltrb(a["bbox"])
-#                 if self.compute_iou(q_, a_) > 0:
-#                     anns_dict[q["category_id"]] = a_
-#                     break
+        # 추후에 중복되는 연산 제거하는 코드로 수정하기!!
+        anns_dict = {}
+        for q in questions:
+            q_ = self.xywh2ltrb(q["bbox"])
+            for a in answers:
+                a_ = self.xywh2ltrb(a["bbox"])
+                if self.compute_iou(q_, a_) > 0:
+                    anns_dict[q["category_id"]] = a_
+                    break
 
-#         return anns_dict
+        return anns_dict
 
-#     def make_qa(self, predict, anns):
-#         """문제에 대응하는 최적의 answer box 찾기
-#            최적의 answer box 기준은 사전의 annotation결과와 iou가 가장 높은 box
-#            iou 값이 0.3 이상인 박스가 없는경우 예측을 못했다고 판단하고 결과로 (0,0,0,0,0,0)을 반환
+    def make_qa(self, predict, anns):
+        """문제에 대응하는 최적의 answer box 찾기
+           최적의 answer box 기준은 사전의 annotation결과와 iou가 가장 높은 box
+           iou 값이 0.3 이상인 박스가 없는경우 예측을 못했다고 판단하고 결과로 (0,0,0,0,0,0)을 반환
 
-#         Args:
-#             predict (List): [[box_info, confidence score,label] ....] box_info = left,top,right,bottom
-#             anns (dict): key : 문제 categori id, value: bbox left,top,right,bottom
+        Args:
+            predict (List): [[box_info, confidence score,label] ....] box_info = left,top,right,bottom
+            anns (dict): key : 문제 categori id, value: bbox left,top,right,bottom
 
-#         Returns:
-#             question_answer (dict):  key : 문제번호, value : [boxinfo, categori_id]
-#         """
-#         question_answer = {}
-#         for q, bbox in anns.items():
-#             iou_list = [self.compute_iou(pred, bbox) for pred in predict]
-#             max_iou = max(iou_list) if iou_list else 0
-#             if max_iou < 0.3:
-#                 question_answer[q - 6] = np.array([0, 0, 0, 0, 0, -1])
-#             else:
-#                 question_answer[q - 6] = predict[iou_list.index(max_iou)]
-#         return question_answer
+        Returns:
+            question_answer (dict):  key : 문제번호, value : [boxinfo, categori_id]
+        """
+        question_answer = {}
+        for q, bbox in anns.items():
+            iou_list = [self.compute_iou(pred, bbox) for pred in predict]
+            max_iou = max(iou_list) if iou_list else 0
+            if max_iou < 0.3:
+                question_answer[q - 6] = np.array([0, 0, 0, 0, 0, -1])
+            else:
+                question_answer[q - 6] = predict[iou_list.index(max_iou)]
+        return question_answer
 
-#     def resize_box(self, q_a_box, img_info, img_shape):
-#         """input의 이미지 size와 사전에 정의된 annotation의 box사이즈를 대응시킴
+    def resize_box(self, q_a_box, img_info, img_shape):
+        """input의 이미지 size와 사전에 정의된 annotation의 box사이즈를 대응시킴
 
-#         Args:
-#             q_a_box : dict : key = 문제, value : 문제에 대응하는 정답박스 정보
-#             img_info : 사전에 정의된 annotation 이미지 정보
-#             img_shape : input 이미지의 사이즈
+        Args:
+            q_a_box : dict : key = 문제, value : 문제에 대응하는 정답박스 정보
+            img_info : 사전에 정의된 annotation 이미지 정보
+            img_shape : input 이미지의 사이즈
 
-#         Returns:
-#             annotation의 size를 적용한
-#             q_a_box : dict : key = 문제, value : 문제에 대응하는 정답박스 정보
-#         """
-#         w_r = img_shape[1] / img_info["width"]
-#         h_r = img_shape[0] / img_info["height"]
+        Returns:
+            annotation의 size를 적용한
+            q_a_box : dict : key = 문제, value : 문제에 대응하는 정답박스 정보
+        """
+        w_r = img_shape[1] / img_info["width"]
+        h_r = img_shape[0] / img_info["height"]
 
-#         q_a_box = {
-#             q: (int(a[0] * w_r), int(a[1] * h_r), int(a[2] * w_r), int(a[3] * h_r))
-#             for q, a in q_a_box.items()
-#         }
-#         return q_a_box
+        q_a_box = {
+            q: (int(a[0] * w_r), int(a[1] * h_r), int(a[2] * w_r), int(a[3] * h_r))
+            for q, a in q_a_box.items()
+        }
+        return q_a_box
 
-#     def save_predict(self, img, img_path, qa_info):
-#         """
-#         predicted img 저장하는 함수!
-#         """
-#         for bbox in qa_info.values():
-#             left, top, right, bottom = bbox[:4].astype(int)
-#             cv2.putText(
-#                 img,
-#                 f"{int(bbox[-1])}   {bbox[-2]:.4f}",
-#                 (left, top - 10),
-#                 cv2.FONT_HERSHEY_COMPLEX,
-#                 0.9,
-#                 (255, 0, 0),
-#                 3,
-#             )
-#             cv2.rectangle(img, (left, top), (right, bottom), (255, 0, 0), 3)
-#             cv2.imwrite(
-#                 f"/opt/ml/input/code/fastapi/app/log/{img_path}_predict.jpg", img
-#             )
+    def save_predict(self, img, img_path, qa_info):
+        """
+        predicted img 저장하는 함수!
+        """
+        for bbox in qa_info.values():
+            left, top, right, bottom = bbox[:4].astype(int)
+            cv2.putText(
+                img,
+                f"{int(bbox[-1])}   {bbox[-2]:.4f}",
+                (left, top - 10),
+                cv2.FONT_HERSHEY_COMPLEX,
+                0.9,
+                (255, 0, 0),
+                3,
+            )
+            cv2.rectangle(img, (left, top), (right, bottom), (255, 0, 0), 3)
+            cv2.imwrite(
+                f"/opt/ml/input/code/fastapi/app/log/{img_path}_predict.jpg", img
+            )
 
-#     def make_user_solution(self, img_save=False, log_save=False):
-#         """
-#         Args:
-#             img_save (bool): 예측한 결과의 사진을 저장할지 여부
-#             log_save(bool): 이미지의 정답과 예측값 그 값에 대응하는 confidence csv 저장
+    def make_user_solution(self, img_save=False, log_save=False):
+        """
+        Args:
+            img_save (bool): 예측한 결과의 사진을 저장할지 여부
+            log_save(bool): 이미지의 정답과 예측값 그 값에 대응하는 confidence csv 저장
 
-#         Returns:
-#             dict: key 문제번호, value : 예측한 체크박스의 번호
-#         """
-#         answer_bbox, a_label = {}, []
-#         images = deepcopy(self.images)
-#         for idx, img in enumerate(images):
-#             img_info, anns = self.load_anns(idx)
-#             predict = self.get_predict(img)
-#             q_a_box = self.match_qa(anns)
-#             q_a_box = self.resize_box(q_a_box, img_info, img.shape)
-#             qa_info = self.make_qa(predict, q_a_box)
-#             answer_bbox.update(qa_info)
+        Returns:
+            dict: key 문제번호, value : 예측한 체크박스의 번호
+        """
+        answer_bbox, a_label = {}, []
+        images = deepcopy(self.images)
+        for idx, img in enumerate(images):
+            img_info, anns = self.load_anns(idx)
+            predict = self.get_predict(img)
+            q_a_box = self.match_qa(anns)
+            q_a_box = self.resize_box(q_a_box, img_info, img.shape)
+            qa_info = self.make_qa(predict, q_a_box)
+            answer_bbox.update(qa_info)
 
-#             if img_save:
-#                 self.save_predict(img, idx, qa_info)
+            if img_save:
+                self.save_predict(img, idx, qa_info)
 
-#             if log_save:
-#                 a_label += [ann for ann in anns if ann["category_id"] <= 6]
+            if log_save:
+                a_label += [ann for ann in anns if ann["category_id"] <= 6]
 
-#         if log_save:
-#             a_b = sorted(answer_bbox.items())
-#             pred_data = pd.DataFrame(
-#                 {
-#                     "label": [a["category_id"] - 1 for a in a_label],
-#                     "predict": [int(bbox[-1]) for q, bbox in a_b],
-#                     "confidence": [bbox[-2] for q, bbox in a_b],
-#                 }
-#             )
-#             if not os.path.isdir("/opt/ml/input/code/fastapi/app/log"):
-#                 os.mkdir("/opt/ml/input/code/fastapi/app/log")
-#             pred_data.to_csv("/opt/ml/input/code/fastapi/app/log/predict_log.csv")
+        if log_save:
+            a_b = sorted(answer_bbox.items())
+            pred_data = pd.DataFrame(
+                {
+                    "label": [a["category_id"] - 1 for a in a_label],
+                    "predict": [int(bbox[-1]) for q, bbox in a_b],
+                    "confidence": [bbox[-2] for q, bbox in a_b],
+                }
+            )
+            if not os.path.isdir("/opt/ml/input/code/fastapi/app/log"):
+                os.mkdir("/opt/ml/input/code/fastapi/app/log")
+            pred_data.to_csv("/opt/ml/input/code/fastapi/app/log/predict_log.csv")
 
-#         user_solution = {q: int(bbox[-1]) for q, bbox in sorted(answer_bbox.items())}
-#         return user_solution
+        user_solution = {q: int(bbox[-1]) for q, bbox in sorted(answer_bbox.items())}
+        return user_solution
 
-    # def save_score_img(self, scoring_result):
-    #     # 채점된 이미지를 만들기 위해 o, x 이미지를 불러오는 부분입니다.
-    #     # TODO: 위의 input이미지의 resize 부분과 함께 고려해야 할 사항입니다.
-        # o_image = Image.open("/opt/ml/input/code/fastapi/app/scoring_image/correct.png")
-        # x_image = Image.open("/opt/ml/input/code/fastapi/app/scoring_image/wrong.png")
-        # o_width, o_height = o_image.size
-        # x_width, x_height = x_image.size
 
-        # # TODO: 현재 paste 좌표가 좌측 하단으로 잡혀있음 (좌측 상단으로 바꿔야함. annotation 정보 확인 필요)
-        # score_img = []
-        # for idx, img in enumerate(self.images):  # fix
-        #     background = Image.fromarray(img)
-        #     question_ann = self.load_anns_q(idx)
-        #     for cat_id, bbox in question_ann.items():
-        #         question = cat_id - 6  # 문제 번호: 1 ~ 30
-        #         if scoring_result[question] == "O":
-        #             background.paste(
-        #                 o_image,
-        #                 (
-        #                     int(bbox[0] - o_width / 2),
-        #                     int(bbox[1] - o_height / 2) + 10,
-        #                 ),
-        #                 o_image,
-        #             )
-        #         elif scoring_result[question] == "X":
-        #             background.paste(
-        #                 x_image,
-        #                 (
-        #                     int(bbox[0] - x_width / 2),
-        #                     int(bbox[1] - x_height / 2) + 10,
-        #                 ),
-        #                 x_image,
-        #             )
-        #     score_img.append(background)
-        # return score_img
+def save_score_img(self, scoring_result):
+    # 채점된 이미지를 만들기 위해 o, x 이미지를 불러오는 부분입니다.
+    # TODO: 위의 input이미지의 resize 부분과 함께 고려해야 할 사항입니다.
+    o_image = Image.open("/opt/ml/input/code/fastapi/app/scoring_image/correct.png")
+    x_image = Image.open("/opt/ml/input/code/fastapi/app/scoring_image/wrong.png")
+    o_width, o_height = o_image.size
+    x_width, x_height = x_image.size
+
+    # TODO: 현재 paste 좌표가 좌측 하단으로 잡혀있음 (좌측 상단으로 바꿔야함. annotation 정보 확인 필요)
+    score_img = []
+    for idx, img in enumerate(self.images):  # fix
+        background = Image.fromarray(img)
+        question_ann = self.load_anns_q(idx)
+        for cat_id, bbox in question_ann.items():
+            question = cat_id - 6  # 문제 번호: 1 ~ 30
+            if scoring_result[question] == "O":
+                background.paste(
+                    o_image,
+                    (
+                        int(bbox[0] - o_width / 2),
+                        int(bbox[1] - o_height / 2) + 10,
+                    ),
+                    o_image,
+                )
+            elif scoring_result[question] == "X":
+                background.paste(
+                    x_image,
+                    (
+                        int(bbox[0] - x_width / 2),
+                        int(bbox[1] - x_height / 2) + 10,
+                    ),
+                    x_image,
+                )
+        score_img.append(background)
+    return score_img
 
 
 # if __name__ == "__main__":
@@ -295,65 +295,69 @@ from datetime import datetime
 #     )
 #     result = inference.make_user_solution(True, True)
 #     print("hi")
-    
+
 
 class Inference_v2:
-    def __init__(self, images, detector, q_bbox, answer, img_shape):
+    def __init__(self, images, detector, q_bbox, answer, img_shape, log_name):
         self.images = images
         self.detector = detector
         self.q_bbox = q_bbox
         self.answer = answer
         self.inference_detector = inference_detector
         self.origin_img_shape = img_shape
-    
-    def xywh2ltrb(self, bbox):
+        self.log_name = log_name
+
+    def ltrb2xywh(self, bbox):
         return [bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1]]
-    
-    def get_predict(self, img, box_threshold=0.1):
+
+    def get_predict(self, img, box_threshold=0.01):
         inference = self.inference_detector(self.detector, img)
         predict = []
         for label, bboxes in enumerate(inference):
             for bbox in bboxes:
                 if bbox[-1] > box_threshold:
-                    predict.append(list(bbox)+[label])
+                    predict.append(list(bbox) + [label])
         return predict
-    
+
     # 사각형 겹침 여부 확인
     def overlap(self, bbox, patch):
-        l1, t1, r1, b1 = bbox[0], bbox[1], bbox[0]+bbox[2], bbox[1]+bbox[3]
-        l2, t2, r2, b2 = patch[0], patch[1], patch[0]+patch[2], patch[1]+patch[3]
+        l1, t1, r1, b1 = bbox[0], bbox[1], bbox[0] + bbox[2], bbox[1] + bbox[3]
+        l2, t2, r2, b2 = patch[0], patch[1], patch[0] + patch[2], patch[1] + patch[3]
 
-        overlap = not (r1 <= l2 or 
-                    l1 >= r2 or 
-                    b1 <= t2 or 
-                    t1 >= b2)
-        return overlap # True면 겹침
-    
+        overlap = not (r1 <= l2 or l1 >= r2 or b1 <= t2 or t1 >= b2)
+        return overlap  # True면 겹침
+
     def resize_box(self, bbox, img_shape):
-        # print(img_shape)
-        # print(self.origin_img_shape)
         w_r = img_shape[1] / self.origin_img_shape[0]
         h_r = img_shape[0] / self.origin_img_shape[1]
-        
-        bbox = [int(bbox[0] * w_r), int(bbox[1] * h_r), int(bbox[2] * w_r), int(bbox[3] * h_r)]
+
+        bbox = [
+            int(bbox[0] * w_r),
+            int(bbox[1] * h_r),
+            int(bbox[2] * w_r),
+            int(bbox[3] * h_r),
+        ]
         return bbox
 
     def save_predict(self, img, img_path, bbox):
-        x, y, w, h = bbox[:4]
-        # cv2.putText(
-        #     img,
-        #     f"{int(bbox[-1])}   {bbox[-2]:.4f}",
-        #     (left, top - 10),
-        #     cv2.FONT_HERSHEY_COMPLEX,
-        #     0.9,
-        #     (255, 0, 0),
-        #     3,
-        # )
-        cv2.rectangle(img, (x, y), (x+w, y+h), (255, 0, 0), 3)
-        cv2.imwrite(
-            f"/opt/ml/input/code/fastapi/app/log/{img_path}_predict.jpg", img
+        x, y, w, h = map(int, bbox[:4])
+        confidence = bbox[4]
+        pred = bbox[5]
+        cv2.putText(
+            img,
+            f"{pred}   {confidence:.4f}",
+            (x, y - 10),
+            cv2.FONT_HERSHEY_COMPLEX,
+            0.9,
+            (255, 0, 0),
+            3,
         )
-    
+        cv2.rectangle(img, (x, y), (x + w, y + h), (255, 0, 0), 3)
+        cv2.imwrite(
+            f"/opt/ml/input/code/fastapi/app/log/{self.log_name}/{img_path}_predict.jpg",
+            img,
+        )
+
     def save_score_img(self, scoring_result):
         # 채점된 이미지를 만들기 위해 o, x 이미지를 불러오는 부분입니다.
         # TODO: 위의 input이미지의 resize 부분과 함께 고려해야 할 사항입니다.
@@ -370,7 +374,6 @@ class Inference_v2:
             img_shape = img.shape
             for q in question:
                 bbox = self.resize_box(question[q], img_shape)
-                self.save_predict(img, idx, bbox)
                 if scoring_result[q] == "O":
                     background.paste(
                         o_image,
@@ -392,34 +395,39 @@ class Inference_v2:
             score_img.append(background)
         return score_img
 
-
     def main(self):
         images = deepcopy(self.images)
         result = dict()
-        # print(datetime.now())
         log_pred = []
         for idx, img in enumerate(images):
             predict = self.get_predict(img)
-            
+
             for i in range(len(predict)):
-                predict[i] = self.xywh2ltrb(predict[i][:4]) + predict[i][4:]
-            log_pred += predict
+                predict[i] = self.ltrb2xywh(predict[i][:4]) + predict[i][4:]
             question = self.q_bbox[idx][0]
+
             for q in question:
+                tmp = []
                 for p in predict:
-                    if self.overlap(question[q], p[:4]):
-                        result[q] = p[-1]
+                    resize_q = self.resize_box(question[q], img.shape)
+                    if self.overlap(resize_q, p[:4]):
+                        p.append(q)
+                        tmp.append(p)
+                if tmp:
+                    tmp = sorted(tmp, key=lambda x: x[4])
+                    pred = tmp[-1]
+                    result[q] = pred[-2]
+                    log_pred.append(pred)
+                    self.save_predict(img, idx, pred)
+
         tmp = [i for i in range(1, 31)]
         for x in result:
             if x in tmp:
-                tmp[x-1] = 0
+                tmp[x - 1] = 0
         for x in tmp:
             if x != 0:
                 result[x] = -1
 
         _score = score(result, self.answer)
-        # print(result)
-        # print(self.answer)
-        # print(_score)
         scoring_img = self.save_score_img(_score)
         return scoring_img, log_pred

--- a/code/fastapi/app/back/inference.py
+++ b/code/fastapi/app/back/inference.py
@@ -310,7 +310,7 @@ class Inference_v2:
     def ltrb2xywh(self, bbox):
         return [bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1]]
 
-    def get_predict(self, img, box_threshold=0.01):
+    def get_predict(self, img, box_threshold=0.1):
         inference = self.inference_detector(self.detector, img)
         predict = []
         for label, bboxes in enumerate(inference):

--- a/code/fastapi/app/back/main.py
+++ b/code/fastapi/app/back/main.py
@@ -9,15 +9,18 @@ from pycocotools.coco import COCO
 from mmdet.apis import init_detector
 import numpy as np
 import sys
+
 # from sqlalchemy.orm import sessionmaker
 # from sqlalchemy import create_engine, Column, String, Integer
 # from sqlalchemy.ext.declarative import declarative_base
-import psycopg2
 
 sys.path.append("/opt/ml/input/code/fastapi/app/back")
 from inference import *
 from utils import *
 
+from database import *
+import uuid
+import os
 
 # settings
 answer_dir = "/opt/ml/input/code/fastapi/app/answer"
@@ -46,7 +49,6 @@ detector = init_detector(model_config, model_weight, device="cuda:0")
 # engine = create_engine("sqlite:///./answer.db")
 # Base.metadata.create_all(bind=engine)
 # SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-db = psycopg2.connect(host="118.67.135.56", dbname="postgres", user="postgres", password="postgres", port=30003) # db 연결
 
 
 # @app.post("/uploadfiles_name/{exam_info}")
@@ -75,28 +77,21 @@ db = psycopg2.connect(host="118.67.135.56", dbname="postgres", user="postgres", 
 #         return {"answers": "No data"}
 
 
-def get_info_from_db(exam_info):
-    answer = pd.read_sql(f'select "QUESTION_PK", "ANSWER" from "ANSWER_TB" Where "TYPE_PK" like \'%{exam_info}%\';', db)
-    question = pd.read_sql(f'select "QUESTION_PK", x, y, w, h, page from "QUESTION_BBOX_TB" Where "TYPE_PK" like \'%{exam_info}%\';', db)
-    img_shape = pd.read_sql(f'select "WIDTH", "HEIGHT" from "PAGE_SHAPE" where "TYPE_PK" like \'%{exam_info}%\';', db)
-    answer = {q: a for q, a in zip(answer['QUESTION_PK'], answer['ANSWER'])}
-    q_bbox = [[dict()] for _ in range(max(question['page']))]
-
-    for q, x, y, w, h, page in zip(question['QUESTION_PK'], question['x'], question['y'], question['w'], question['h'], question['page']):
-        q_bbox[page-1][0].update({q: [x, y, w, h]})
-
-    img_shape = [img_shape['WIDTH'][0], img_shape['HEIGHT'][0]]
-
-    # db.close() # 매번 close?
-    return answer, q_bbox, img_shape
-
-
 # 이미지를 불러와서 모델 예측을 수행하는 부분입니다.
 @app.post("/predict/{exam_info}")
 def predict(exam_info: str, file: UploadFile = File(...)):
     answer, q_bbox, img_shape = get_info_from_db(exam_info)
     images = convert_from_bytes(file.file._file.read())
     images_np = [np.array(image) for image in images]
+    log_name = uuid.uuid1()
+
+    if not os.path.isdir(f"/opt/ml/input/code/fastapi/app/log/{log_name}"):
+        os.mkdir(f"/opt/ml/input/code/fastapi/app/log/{log_name}")
+
+    for idx in range(len(images_np)):
+        Image.fromarray(images_np[idx]).save(
+            f"/opt/ml/input/code/fastapi/app/log/{log_name}/{idx}_original.jpg", "JPEG"
+        )
 
     inference = Inference_v2(
         images=images_np,
@@ -104,9 +99,10 @@ def predict(exam_info: str, file: UploadFile = File(...)):
         q_bbox=q_bbox,
         answer=answer,
         img_shape=img_shape,
+        log_name=log_name,
     )
     scoring_img, log_pred = inference.main()
-    # print(log_pred)
+    insert_log(log_pred, exam_info, log_name)
 
     imgByteArr = io.BytesIO()
     scoring_img[0].save(


### PR DESCRIPTION
## Overview
- main에 있던 database 분리
- log 기록되게 만듦
- 오류 수정


## Change Log
1. 건혁님께서 주신 아이디어로 수정: inference 부분에서 문제와 겹치는 보기 중 confidence score가 제일 높은 박스를 답으로 인식하게끔 수정
2. main에 있던 database를 database.py 파일로 분리하고 database의 정보는 slack에 업로드
3. 사용자의 input과 예측한 이미지(건혁님께서 만들어주신 이미지 - 박스, 예측한 라벨, confidence score가 표시되는 이미지)가 저장됨 -> ~~주영님께서 주신 아이디어대로 uuid를 이름으로 가지는 디렉토리를 만들고~~ 그 안에 log image들이 저장됨 -> 시간으로 디렉토리 만듦
5. log가 찍히는 코드를 추가
- LOG 테이블: 예측 정보가 쌓임
- ~~LOG_UUID: 예측 시간과 uuid가 쌓임~~
- ~~두 테이블은 예측 시간으로 연결됨~~
6. black formatter 적용
7. 쿼리문 읽기 편하게 줄바꿈 추가

## To Reviewer
어려운 점이 있다면 언제든 말씀해주세요. 감사합니다.
